### PR TITLE
remove overlay from menus for now

### DIFF
--- a/.changeset/three-camels-hug.md
+++ b/.changeset/three-camels-hug.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Fix: remove background overlay from menu components

--- a/src/lib/bits/context-menu/components/ContextMenuContent.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuContent.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import Overlay from "$lib/internal/overlay.svelte";
-
 	import { createDispatcher } from "$lib/internal/events.js";
 
 	import { melt } from "@melt-ui/svelte";
@@ -30,10 +28,6 @@
 
 	const dispatch = createDispatcher();
 </script>
-
-{#if $open}
-	<Overlay />
-{/if}
 
 {#if asChild && $open}
 	{@const builder = $menu}

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuContent.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuContent.svelte
@@ -2,7 +2,6 @@
 	import { createDispatcher } from "$lib/internal/events.js";
 
 	import { melt } from "@melt-ui/svelte";
-	import Overlay from "$lib/internal/overlay.svelte";
 	import type { Transition } from "$lib/internal/types.js";
 	import { ctx } from "../ctx.js";
 	import type { ContentEvents, ContentProps } from "../types.js";
@@ -34,9 +33,6 @@
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions applied by melt's action/store -->
-{#if $open}
-	<Overlay />
-{/if}
 {#if asChild && $open}
 	{@const builder = $menu}
 	<slot {builder} />

--- a/src/lib/bits/select/components/SelectContent.svelte
+++ b/src/lib/bits/select/components/SelectContent.svelte
@@ -2,7 +2,6 @@
 	import { createDispatcher } from "$lib/internal/events.js";
 
 	import { melt } from "@melt-ui/svelte";
-	import Overlay from "$lib/internal/overlay.svelte";
 	import type { Transition } from "$lib/internal/types.js";
 	import { ctx } from "../ctx.js";
 	import type { ContentEvents, ContentProps } from "../types.js";
@@ -30,9 +29,6 @@
 
 <!-- svelte-ignore a11y-no-static-element-interactions / applied by melt's builder-->
 
-{#if $open}
-	<Overlay />
-{/if}
 {#if asChild && $open}
 	{@const builder = $menu}
 	<slot {builder} />


### PR DESCRIPTION
I previously added an overlay behind the menus to indicate that you can't directly interact with something outside of the menu without unexpected side effects while the menu is open. However, this should be handled more elegantly, so I'm removing the overlay until an alternative solution is decided.